### PR TITLE
Update dependency map for dev mode detector

### DIFF
--- a/dependency-map.json
+++ b/dependency-map.json
@@ -21,7 +21,7 @@
   },
   "vaadin-development-mode-detector": {
     "npm": "@vaadin/vaadin-development-mode-detector",
-    "semver": "^1.0.3-pre.5"
+    "semver": "^1.0.3-pre.6"
   },
   "vaadin-button": {
     "npm": "@vaadin/vaadin-button",


### PR DESCRIPTION
This version no longer attempts to import `@polymer/polymer/lib/utils/import-href.js` which has been removed from Polymer in 3.0.1 patch release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/magi-cli/12)
<!-- Reviewable:end -->
