### PR TITLE
Do not fail if there are no npm releases before

### DIFF
--- a/bin/magi-release
+++ b/bin/magi-release
@@ -110,7 +110,11 @@ async function main(version) {
   }
 
   /* Check whether this version is already publised in NPM */
-  const npmInfo = await exe(`npm info ${workingPackage.name}@${newVersion}`, true);
+  let npmInfo;
+  try {
+    npmInfo = await exe(`npm info ${workingPackage.name}@${newVersion}`, true);
+  } catch (ignore) {
+  }
   let npmUrl = `https://www.npmjs.com/package/${workingPackage.name}`;
 
   if (npmInfo) {


### PR DESCRIPTION
In case of a new component, there will be no releases during the first run. No need to fail in that case.