### PR TITLE
Remove node_modules before p3-convert

### DIFF
--- a/bin/magi-release
+++ b/bin/magi-release
@@ -117,6 +117,7 @@ async function main(version) {
     done(`Release Already deployed in NPM: ${npmUrl}`);
   } else {
     info('Converting to polymer 3');
+    await exe('npx rimraf node_modules');
     await exe('magi p3-convert --out . --import-style=name');
     done('Converted to Polymer 3')
 


### PR DESCRIPTION
The same as https://github.com/vaadin/vaadin-element-skeleton/blob/master/.travis.yml#L56

`polymer-modulizer` produces random errors with `node_modules` folder presented:

![image](https://user-images.githubusercontent.com/6059356/44334700-f947d580-a47a-11e8-90d3-aca477c51e93.png)
