### PR TITLE
Unpin Polymer since the next 2.x release is done

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -67,15 +67,6 @@ async function main() {
     runSync('git add demo/demos.json');
   }
 
-  const hasPolymerDependency = bowerJson.dependencies && bowerJson.dependencies.polymer;
-  if (hasPolymerDependency) {
-    // TODO(web-padawan): revert commit once the next 2.x release after 2.6.0 lands
-    const pinPolymer = '5f5d2c2';
-    bowerJson.dependencies.polymer = `Polymer/polymer#${pinPolymer}`;
-    const resolutions = bowerJson.resolutions || {};
-    bowerJson.resolutions = {...resolutions, polymer: `${pinPolymer}`};
-  }
-
   jsonfile.writeFileSync('bower.json', bowerJson, {spaces: 2});
 
   runSync('git add bower.json');


### PR DESCRIPTION
Note: leaving `bower up` so that we make sure the 2.6.1 gets picked up when doing release locally.