### PR TITLE
Add default P3 post-process config to use html-tag

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -3,6 +3,7 @@
 
 const {workingPackage} = require('../lib/tools.js');
 const {EOL} = require('os');
+const {files, from, to} = require('../lib/p3-post.js')
 const path = require('path');
 const fs = require('fs');
 const jsonfile = require('jsonfile');
@@ -114,6 +115,9 @@ async function main() {
       ${process.argv.slice(2).join(' ')} \
   `);
 
+  // Set default values for replacements
+  const postProcess = {files, from, to};
+
   // Run custom project adjustments
   let postFile = 'magi-p3-post.json';
   let magiPost = jsonfile.readFileSync(postFile, {throws: false});
@@ -126,11 +130,22 @@ async function main() {
   }
 
   if (magiPost) {
-    // magiPost json is a valid options object for 'replace-in-file'
-    replace.sync(magiPost);
-    // we don't need "magi-p3-post" anymore
-    (magiPost.remove || []).concat(postFile).forEach(file => fs.unlinkSync(file));
+    magiPost.files = [...postProcess.files, ...magiPost.files];
+    magiPost.from = [...postProcess.from, ...magiPost.from];
+    magiPost.to = [...postProcess.to, ...magiPost.to];
+  } else {
+    magiPost = postProcess;
   }
+
+  // magiPost json is a valid options object for 'replace-in-file'
+  replace.sync(magiPost);
+
+  const filesToRemove = magiPost.remove || [];
+  // we don't need "magi-p3-post" anymore
+  if (fs.existsSync(postFile)) {
+    filesToRemove.push(postFile);
+  }
+  filesToRemove.forEach(file => fs.unlinkSync(file));
 }
 
 main()

--- a/lib/p3-post.js
+++ b/lib/p3-post.js
@@ -1,0 +1,22 @@
+const fixme = `
+/*
+  FIXME(polymer-modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this comment!
+*/
+;`
+ module.exports = {
+  files: [
+    "theme/**/*-styles.js"
+  ],
+  from: [
+    "const $_documentContainer = document.createElement('template');",
+    "$_documentContainer.innerHTML = `",
+    fixme
+  ],
+  to: [
+    "import { html } from '@polymer/polymer/lib/utils/html-tag.js';",
+    "const $_documentContainer = html`",
+    ""
+  ]
+}


### PR DESCRIPTION
## Description

As a developer, I want to use the tagged template literals (instead of usual template literals) when converting to Polymer 3, in order to get the proper support for modern tools and plugins.
Requested in Polymer/polymer-modulizer#449 but I was unable to quickly implement it there.

### Current

```js
const $_documentContainer = document.createElement('template');

$_documentContainer.innerHTML = `<custom-style>
  <style>
    html {
      --lumo-size-xs: 1.625rem;
      --lumo-size-s: 1.875rem;
      --lumo-size-m: 2.25rem;
      --lumo-size-l: 2.75rem;
      --lumo-size-xl: 3.5rem;

      /* Icons */
      --lumo-icon-size-s: 1.25em;
      --lumo-icon-size-m: 1.5em;
      --lumo-icon-size-l: 2.25em;
      /* For backwards compatibility */
      --lumo-icon-size: var(--lumo-icon-size-m);
    }
  </style>
</custom-style>`;

document.head.appendChild($_documentContainer.content);
```

### Expected

```js
import { html } from '@polymer/polymer/lib/utils/html-tag.js';

const $_documentContainer = html`<custom-style>
  <style>
    html {
      --lumo-size-xs: 1.625rem;
      --lumo-size-s: 1.875rem;
      --lumo-size-m: 2.25rem;
      --lumo-size-l: 2.75rem;
      --lumo-size-xl: 3.5rem;

      /* Icons */
      --lumo-icon-size-s: 1.25em;
      --lumo-icon-size-m: 1.5em;
      --lumo-icon-size-l: 2.25em;
      /* For backwards compatibility */
      --lumo-icon-size: var(--lumo-icon-size-m);
    }
  </style>
</custom-style>`;

document.head.appendChild($_documentContainer.content);
```

### Possible benefits
- support for [babel-plugin-template-html-minifier](https://github.com/goto-bus-stop/babel-plugin-template-html-minifier): easy to minify CSS, especially remove comments from the above code
- support for [VSCode plugin](https://github.com/mjbvz/vscode-lit-html) syntax highlighting

### Possible negative effects
- code transpiled by Babel will get larger because of how it transpiles tagged template literals, but the outcome does not seem noticeable, especially when compared with benefit of CSS minifying

### Note

We will have to make sure we do not have duplicate `@polymer/polymer/lib/utils/html-tag.js` import, happens at least in dropdown-menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/magi-cli/55)
<!-- Reviewable:end -->
