### PR TITLE
GitHub API: support env.GH_TOKEN, remove excessive username

### DIFF
--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -4,28 +4,19 @@ const {ask, config, createAPI} = require('./tools.js');
 const GitHub = require('github-api');
 
 async function getGitHubApi(auth) {
-  let {username, token} = config.has('github.com') ? config.get('github.com') : {};
-  if (auth || !username || !token) {
-    console.log('Please provide your GitHub.com authentication credentials')
-    const usernameAnswer = await ask(`Username${username ? ` (${username})` : ''}: `);
-    if (usernameAnswer) username = usernameAnswer;
-    if (!username) {
-      throw 'Empty username';
-    } else {
-      config.set('github.com.username', username);
-    }
-
-    console.log('Generate OAuth personal access token here: https://github.com/settings/tokens/new?scopes=repo')
+  let token = process.env.GH_TOKEN || config.get('github.com.token');
+  if (auth || !token) {
+    console.log('Please provide your GitHub personal access token, https://github.com/settings/tokens/new?scopes=repo')
     const tokenAnswer = await ask(`Token${token ? ' (press enter to use saved)' : ''}: `);
     if (tokenAnswer) token = tokenAnswer;
     if (!token) {
-      throw 'Empty token';
+      throw 'Empty GitHub token';
     } else {
       config.set('github.com.token', token);
     }
   }
 
-  return new GitHub({username, token});
+  return new GitHub({token});
 }
 
 module.exports.getGitHubApi = getGitHubApi;


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-demo-helpers/pull/50 (the very first implementation of `semantic-release` + `magi`)

According to GitHub API docs http://github-tools.github.io/github/examples/authorization username isn't needed when authorizing with token.

Also, in order to work in TravisCI, `magi` should be able to use the `GH_TOKEN` environment variable.