### PR TITLE
feat(release): setup Git for pushing from CI env

### DIFF
--- a/bin/magi-release
+++ b/bin/magi-release
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const isCi = require('is-ci');
 const program = require('commander');
-const readline = require('readline');
 const fs = require('fs');
 
 function info(msg) {
@@ -60,6 +60,10 @@ async function main(version) {
   } else {
     info(`Creating ${newVersion} tag and commit`);
     await exe(`npm version ${newVersion}`, true);
+  }
+
+  if (isCi) {
+    await setupGitForCI(workingPackage.repository)
   }
 
   const tagUrl = `https://github.com/${workingPackage.repository}/blob/v${newVersion}/package.json`;

--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const {ask, config, createAPI} = require('./tools.js');
+const {ask, config, getGitHubToken} = require('./tools.js');
 const GitHub = require('github-api');
 
 async function getGitHubApi(auth) {
-  let token = process.env.GH_TOKEN || config.get('github.com.token');
+  let token = getGitHubToken();
   if (auth || !token) {
     console.log('Please provide your GitHub personal access token, https://github.com/settings/tokens/new?scopes=repo')
     const tokenAnswer = await ask(`Token${token ? ' (press enter to use saved)' : ''}: `);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -21,6 +21,15 @@ module.exports.checkForUpdates = function () {
   }).notify();
 }
 
+/**
+ * Setup Git to be able to push to GitHub
+ */
+module.exports.setupGitForCI = async function (repository) {
+  await exe('git config --global user.email "travis@travis-ci.org"')
+  await exe('git config --global user.name "Travis CI"')
+  await exe(`git remote set-url origin https://${getGitHubToken()}@github.com/${repository}.git`)
+}
+
 const asyncExec = require('util').promisify(require('child_process').exec);
 /**
  * Runs the command and captures the stdout
@@ -90,6 +99,9 @@ const Configstore = require('configstore');
 const config = new Configstore(cliPackageName);
 module.exports.config = config;
 
+function getGitHubToken() {
+  return process.env.GH_TOKEN || config.get('github.com.token')
+}
 
 function applyDefaults(apiConfig) {
   const defaults = {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@semantic-release/changelog": "^3.0.0",
     "@semantic-release/git": "^7.0.3",
     "@semantic-release/npm": "^5.0.4",
+    "is-ci": "^1.2.0",
     "semantic-release": "^15.9.12"
   }
 }


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-demo-helpers/pull/50 (the very first implementation of `semantic-release` + `magi`)

Also, in order to push from TravisCI, Git user should be set and GitHub token should be in origin url.

Reference: https://gist.github.com/willprice/e07efd73fb7f13f917ea