### PR TITLE
fix(release): add --tag to npm publish command, remove npm dist-tag

### DIFF
--- a/bin/magi-release
+++ b/bin/magi-release
@@ -135,14 +135,10 @@ async function main(version) {
       done('Converted to Polymer 3')
 
       info('Publishing to npm');
-      await exe('npm publish --access public');
-      done(`Deployed in npm at: ${npmUrl}`);
-
-      info('Updating tag in npm');
       const next = /(alpha|beta|pre|rc)[.]*[0-9]+$/;
       const tag = next.test(newVersion) ? 'next' : 'latest';
-      await exe(`npm dist-tag add ${workingPackage.name}@${newVersion} ${tag}`);
-      done(`Updated tag in npm to ${tag}`);
+      await exe(`npm publish --access public --tag ${tag}`);
+      done(`Deployed to npm: ${npmUrl} with tag ${tag}`);
 
       info('Reverting P3 back to P2');
       await exe('git reset --hard HEAD^', true);


### PR DESCRIPTION
Fixes #68 

As per [docs](https://docs.npmjs.com/cli/publish#description):

> [--tag <tag>] Registers the published package with the given tag, such that npm install <name>@<tag> will install this version. By default, npm publish updates and npm install installs the latest tag. See npm-dist-tag for details about tags.

Previously we were not specifying `--tag` for `npm publish` which means we were always updating `latest`.

By adding `--tag` to `npm publish` we will ensure that only needed tag is updated: either `latest` or `next`, depending on the version number.