### PR TITLE
Add p3-convert verification

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -115,6 +115,12 @@ async function main() {
       ${process.argv.slice(2).join(' ')} \
   `);
 
+  // check that conversion went well and the primary entry point is there
+  const packageJson = JSON.parse(fs.readFileSync('package.json'));
+  if (!fs.existsSync(packageJson.main)) {
+    throw `⚠️ Something went wrong during P3 convert, ${packageJson.main} wasn't found.`;
+  }
+
   // Set default values for replacements
   const postProcess = {files, from, to};
 


### PR DESCRIPTION
Fixed #72 

This will prevent npm publishing if something went wrong during `pe-convert`.