### PR TITLE
feat: use bundled-es-modules version of pdfjs-dist

### DIFF
--- a/dependency-map.json
+++ b/dependency-map.json
@@ -12,8 +12,8 @@
     "semver": "6.1.4"
   },
   "pdfjs-dist": {
-    "npm": "pdfjs-dist",
-    "semver": "2.0.943"
+    "npm": "@bundled-es-modules/pdfjs-dist",
+    "semver": "2.0.943-viewer"
   },
   "polymer": {
     "npm": "@polymer/polymer",


### PR DESCRIPTION
Connected to vaadin/vaadin-pdf-viewer#19

I was able to make Polymer 3 tests pass locally with that version, so let's include it here.