### PR TITLE
fix(p3-convert): delete husky git hooks config in package.json

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -31,6 +31,9 @@ async function main() {
     throw 'Error: expected working directory to have clean git repository state';
   }
 
+  // Delete husky config in package.json
+  delete workingPackage.husky;
+
   // Delete devDependencies in package.json
   delete workingPackage.devDependencies;
 


### PR DESCRIPTION
The following error starter do appear when running `magi p3-convert` locally:

```sh
husky > pre-commit (node v10.14.0)
npm ERR! missing script: lint

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/sergey/.npm/_logs/2019-03-22T07_13_55_819Z-debug.log
husky > pre-commit hook failed (add --no-verify to bypass)
Git repo is dirty. Check all changes in to source control and then try again.
```

Note: in Travis it does not fail, as `husky` is properly detecting that `npm install` is running in CI environment, and skips setting up git hooks in that case. So this is only for local converting.