### PR TITLE
fix: run check-version in update-version

### DIFF
--- a/bin/magi-release
+++ b/bin/magi-release
@@ -35,13 +35,6 @@ const {getGitHubApi} = require('../lib/github-api.js');
 
 async function main(version) {
 
-  /* Check if component version is correct */
-  try {
-    await exe('magi check-version');
-  } catch (e) {
-    throw new Error('Version getter is out of sync with package.json. Cannot release');
-  }
-
   /* Check if Bower dependencies have correct ranges */
   try {
     await exe('magi check-bower');

--- a/bin/magi-update-version
+++ b/bin/magi-update-version
@@ -19,6 +19,13 @@ if (!version) {
 }
 
 async function main() {
+  /* Check if component version is correct */
+  try {
+    await exe('magi check-version');
+  } catch (e) {
+    throw new Error('Version getter is out of sync with package.json. Cannot release');
+  }
+
   const newVersion = version.replace(/^v/, '');
   const changes = await replace({files: ['src/*.html'], from: oldVersion, to: newVersion});
   // Stage the changes for the new version tag commit


### PR DESCRIPTION
I have just realised that in some cases we don't need to check version getters, especially for releasing mixins (e.g. `vaadin-list-mixin`), demo helpers etc. So updating script to move this part from `release` to `update-version` which should be only listed in package.json when needed.