### PR TITLE
fix: cleanup after generating TS defs

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -185,6 +185,13 @@ async function main() {
 
     runSync('npm run generate-typings');
   }
+
+  // Remove gen-typescript-declarations
+  replace.sync({
+    files: ['package.json'],
+    from: /.*"@polymer\/gen-typescript-declarations": "\^1\.6\.2",*\n/g,
+    to: ''
+  });
 }
 
 main()


### PR DESCRIPTION
This change is needed to make sure `yarn install --flat` works in Travis and make builds green.