### PR TITLE
fix: replace all occurrences of version

### DIFF
--- a/bin/magi-update-version
+++ b/bin/magi-update-version
@@ -26,8 +26,9 @@ async function main() {
     throw new Error('Version getter is out of sync with package.json. Cannot release');
   }
 
+  const fromRegex = new RegExp(oldVersion, 'g');
   const newVersion = version.replace(/^v/, '');
-  const changes = await replace({files: ['src/*.{html,ts}'], from: oldVersion, to: newVersion});
+  const changes = await replace({files: ['src/*.{html,ts}'], from: fromRegex, to: newVersion});
   // Stage the changes for the new version tag commit
   if (changes.length) {
     await exe(`git update-index -- ${changes.join(' ')}`);


### PR DESCRIPTION
Some components, like vaadin-charts, mention the component version in multiple locations. 
Without this change only the first occurrence is updated.
Fixes #96