### PR TITLE
fix(p3-convert): add export for TS interfaces

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -191,6 +191,16 @@ async function main() {
     runSync('npm install');
 
     runSync('npm run generate-typings');
+
+    if (fs.existsSync(path.join('@types', 'interfaces.d.ts'))) {
+      console.log('Adding @types export');
+      const entry = packageJson.main.replace('.js', '');
+      replace.sync({
+        files: [`${entry}.d.ts`],
+        from: `export * from './src/${entry}.js'`,
+        to: `export * from './src/${entry}.js';\nexport * from './@types/interfaces'`
+      });
+    }
   }
 
   // Remove gen-typescript-declarations


### PR DESCRIPTION
Fixes #115 

If `@types/interfaces.d.ts` is found, add export line to the `d.ts` file corresponding to the main entrypoint specified as `"main"` field in `package.json`.

At this point we are sure that the entrypoint exists because we check for its presence:
https://github.com/vaadin/magi-cli/blob/89cf7757a1955b985eba19b5ceef3f0c262c35fb/bin/magi-p3-convert#L128-L129