### PR TITLE
fix: use custom gen-typescript-declarations

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -206,7 +206,7 @@ async function main() {
   // Remove gen-typescript-declarations
   replace.sync({
     files: ['package.json'],
-    from: /.*"@polymer\/gen-typescript-declarations": "\^1\.6\.2",*\n/g,
+    from: /.*"@web-padawan\/gen-typescript-declarations": "\^1\.6\.2",*\n/g,
     to: ''
   });
 }

--- a/lib/p3-post.js
+++ b/lib/p3-post.js
@@ -10,7 +10,7 @@ const tsDefs = `"scripts": {
   "generate-typings": "gen-typescript-declarations --outDir . --verify"
 },
 "devDependencies": {
-  "@polymer/gen-typescript-declarations": "^1.6.2",`;
+  "@web-padawan/gen-typescript-declarations": "^1.6.2",`;
 
  module.exports = {
   files: [


### PR DESCRIPTION
Include fix for `@attribute` JSDoc tags for properties needed by `web-component-analyzer`, see https://github.com/Polymer/tools/pull/3508

This is needed to fix https://github.com/vaadin/vaadin-grid/issues/1774 and https://github.com/vaadin/vaadin-combo-box/issues/896