### PR TITLE
feat: do not pin Polymer in p3-convert

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -73,19 +73,9 @@ async function main() {
     runSync('git add demo/demos.json');
   }
 
-  const hasPolymerDependency = bowerJson.dependencies && bowerJson.dependencies.polymer;
-  if (hasPolymerDependency) {
-    // TODO(web-padawan): revert commit once the next 2.x release after 2.6.0 lands
-    const pinPolymer = '5f5d2c2';
-    bowerJson.dependencies.polymer = `Polymer/polymer#${pinPolymer}`;
-    const resolutions = bowerJson.resolutions || {};
-    bowerJson.resolutions = {...resolutions, polymer: `${pinPolymer}`};
-  }
-
   jsonfile.writeFileSync('bower.json', bowerJson, {spaces: 2});
 
   runSync('git add bower.json');
-  rimraf.sync('bower_components');
   runSync('bower install');
 
   // Try commit changes


### PR DESCRIPTION
This workaround is no longer needed as now we get Polymer 2.8.0 when running `bower install`.