### PR TITLE
fix: handle markers inside theme mixins folders

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -49,7 +49,7 @@ async function main() {
 
   // Visit all source files and replace MAGI markers
   replace.sync({
-    files: ['*.js', '*.html', 'src/*', 'demo/*', 'test/*', 'test/visual/*', 'theme/*/*'],
+    files: ['*.js', '*.html', 'src/*', 'mixins/*', 'demo/*', 'test/*', 'test/visual/*', 'theme/*/*'],
     from: [/.*MAGI ADD (START|END).*\n/g, /.*MAGI REMOVE START[\s\S]*?MAGI REMOVE END.*\n/g],
     to: ''
   });


### PR DESCRIPTION
This is a finding from working on https://github.com/vaadin/vaadin-lumo-styles/pull/94