### PR TITLE
feat: release and deploy P3 components

### DIFF
--- a/bin/magi-deploy
+++ b/bin/magi-deploy
@@ -4,6 +4,7 @@
 const program = require('commander');
 program
   .option('--auth', 'Ask and replace saved Bender authentication credentials')
+  .option('--next', 'Deploy Polymer 3 / LitElement based component')
   .parse(process.argv);
 
 const {workingPackage, elementName, createAPI} = require('../lib/tools.js');
@@ -36,9 +37,10 @@ async function main() {
   } catch (ignore) {
   }
 
+  const id = program.next ? 'CoreElements_DeployTest_MdeployNext' : 'CoreElements_DeployTest_Mdeploy';
   const tmp = workingPackage.repository.split('/');
   const response = await api.post(`/buildQueue`, {
-    buildType: {id: 'CoreElements_DeployTest_Mdeploy'},
+    buildType: {id},
     properties: {
       property: [
         {name: 'repo', value: tmp[0]},

--- a/bin/magi-release
+++ b/bin/magi-release
@@ -126,6 +126,9 @@ async function main(version) {
     }
   }
 
+  // Detect if the component is P2 or "next"
+  const isP2 = fs.existsSync('bower.json');
+
   /* Check whether this version is already published in npm */
   if (program.skipNpm) {
     info('Skipping npm Release');
@@ -140,10 +143,13 @@ async function main(version) {
     if (npmInfo) {
       done(`Release Already deployed in npm: ${npmUrl}`);
     } else {
-      info('Converting to polymer 3');
-      rimraf.sync('node_modules');
-      await exe('magi p3-convert --out . --import-style=name');
-      done('Converted to Polymer 3')
+      // P2 component: convert to P3
+      if (isP2) {
+        info('Converting to polymer 3');
+        rimraf.sync('node_modules');
+        await exe('magi p3-convert --out . --import-style=name');
+        done('Converted to Polymer 3');
+      }
 
       info('Publishing to npm');
       if (branch === 'master') {
@@ -157,9 +163,12 @@ async function main(version) {
         done(`Deployed to npm: ${npmUrl}`);
       }
 
-      info('Reverting P3 back to P2');
-      await exe('git reset --hard HEAD^', true);
-      await exe('git clean -fd', true);
+      // P2 component: restore master
+      if (isP2) {
+        info('Reverting P3 back to P2');
+        await exe('git reset --hard HEAD^', true);
+        await exe('git clean -fd', true);
+      }
     }
   }
 
@@ -168,12 +177,13 @@ async function main(version) {
     info('Skipping CDN Deployment');
   } else {
     info('Deploying to demo server');
-    await exe(`magi deploy v${newVersion}`);
-    done(`Deployed in CDN at: https://cdn-origin.vaadin.com/${elementName}/${newVersion}/demo/`);
+    const args = isP2 ? '' : '--next';
+    await exe(`magi deploy v${newVersion}${args}`);
+    done(`Deployed in CDN at: https://cdn-origin.vaadin.com/${elementName}/${newVersion}/`);
   }
 
   /* WebJar */
-  if (program.skipWebjar) {
+  if (program.skipWebjar || !isP2) {
     info('Skipping Webjar Deployment');
   } else {
     info('Deploying to webjar');


### PR DESCRIPTION
1. Updated `deploy` script to take `--next` flag which will run the corresponding [build](https://bender.vaadin.com/viewType.html?buildTypeId=CoreElements_DeployTest_MdeployNext),
2. Updated `release` script to skip P3 conversion and webjar when publishing P3 components.