### PR TITLE
fix: use strict regex for version update

### DIFF
--- a/bin/magi-update-version
+++ b/bin/magi-update-version
@@ -26,8 +26,8 @@ async function main() {
     throw new Error('Version getter is out of sync with package.json. Cannot release');
   }
 
-  const fromRegex = new RegExp(oldVersion, 'g');
-  const newVersion = version.replace(/^v/, '');
+  const fromRegex = new RegExp(`'${oldVersion.split('.').join('\\.')}'`, 'g');
+  const newVersion = `'${version.replace(/^v/, '')}'`;
   const changes = await replace({files: ['src/*.{html,js,ts}'], from: fromRegex, to: newVersion});
   // Stage the changes for the new version tag commit
   if (changes.length) {


### PR DESCRIPTION
Fixes #131

There was a problem in the regex, which was looking like this:  /2.0.0/g

It contains some unescaped `.` characters which results in the following replacements:
https://github.com/vaadin/vaadin-avatar/commit/dea89381995e5bfc918d86463fa9366e3b3cbc0e#diff-2021ab67f0e3ad122faeffcf7d2b1aaa676745cb545c089d534efd492735f40dL80-L81

Also, the single quotes around version are lacking which might also affect some files.