### PR TITLE
fix!: detect new package version using process.env.npm_new_version

### DIFF
--- a/bin/magi-update-version
+++ b/bin/magi-update-version
@@ -2,7 +2,7 @@
 'use strict';
 
 // Should be run from 'preversion'
-// Assumes that the old version is in package.json and the new version is in npm_package_version environment variable.
+// Assumes that the old version is in package.json and the new version is in npm_new_version environment variable.
 const replace = require('replace-in-file');
 const {exe, workingPackage} = require('../lib/tools.js');
 
@@ -12,9 +12,9 @@ if (!oldVersion) {
   process.exit(1);
 }
 
-const version = process.env.npm_package_version;
+const version = process.env.npm_new_version;
 if (!version) {
-  console.log('New version must be given as a npm_package_version environment variable.');
+  console.log('New version must be given as a npm_new_version environment variable.');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Description

Currently running `magi release` can lead to the version getter in the sources not being updated to the new package version. The issue is that the `update-version` script uses the `npm_package_version` env variable to get the new package version. However it seems that this was an NPM bug, and the variable was supposed to contain the current package version. NPM 7 fixed the issue, which means running the command with NPM 7 leads to the sources not being updated anymore (replaces current version with current version -> no changes)

Updated the `update-version` script to use the `npm_new_version` variable instead. Tested by running `npm link` from the magi repo (might need to uninstall globally first), and then running `npm --no-git-tag-version version <version>` from a Vaadin component repo.

Fixes https://github.com/vaadin/magi-cli/issues/133

## Type of change

- [x] Bugfix
