### PR TITLE
fix: make check-releases filter for commits that should be included

### DIFF
--- a/bin/magi-check-releases
+++ b/bin/magi-check-releases
@@ -13,6 +13,7 @@ const readline = require('readline');
 
 const semverVersionString = /((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/;
 const versionString = /^(Version |Release |)((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/;
+const releaseWorthyCommitMessageString = /^(fix|feat|refactor|docs):/;
 const successColor = '\x1b[32m';
 const failedColor = '\x1b[31m';
 const neutralColor = '\x1b[36m';
@@ -40,14 +41,21 @@ async function main() {
     let commitsObj;
     try {
       commitsObj = await componentRepo.listCommits();
-      const commits = commitsObj.data.map(item => item.commit.message).filter(msg => !/chore|docs|test|build|ci/.test(msg));
+      // Filter for commits that either:
+      // - include a fix, feature, refactoring, documentation update
+      // - or indicate a version release
+      const filteredCommits = commitsObj.data.map(item => item.commit.message).filter(msg =>
+          releaseWorthyCommitMessageString.test(msg) ||
+          versionString.test(msg)
+      );
 
-      const latestRelease = commits.find(item => versionString.test(item)) || 'No version found';
+      const latestRelease = filteredCommits.find(item => versionString.test(item)) || 'No version found';
       const latestReleaseVersion = latestRelease.match(semverVersionString)[0];
-      const latestReleaseIndex = commits.indexOf(latestRelease);
+      const latestReleaseIndex = filteredCommits.indexOf(latestRelease);
 
       const platformVersionString = alignStringLength(platformString, item.version);
       const ghVersionString = alignStringLength(ghString, latestReleaseVersion);
+      // If the latest release is not the first of the filtered commits, then we have something that needs a release
       const numberOfCommitsString = (latestReleaseIndex > 0) ?
         alignStringLength(numberString, latestReleaseIndex) :
         alignStringLength(numberString, 0);


### PR DESCRIPTION
Currently the check-releases command looks for commits that do not include `chore|docs|test|build|ci`. That means it will also report false positives, if an older commit did not use conventional commit messages.

This change reverses the filter to look explicitely for commits that should be released, which means they use conventional commit messages, and match `/^(fix|feat|refactor|docs):/`.

Testing this it:
- correctly ignores false positives, for example in:
  - `vaadin-accordion` https://github.com/vaadin/vaadin-accordion/commits/master
  - `vaadin-button` https://github.com/vaadin/vaadin-button/commits/master
  - `vaadin-details` https://github.com/vaadin/vaadin-details/commits/master
- correctly reports unreleased changes, for example in:
  - `vaadin-combobox` https://github.com/vaadin/vaadin-combo-box/commits/master
  - `vaadin-messages` https://github.com/vaadin/vaadin-messages/commits/master
  - `vaadin-upload` https://github.com/vaadin/vaadin-upload/commits/master