### PR TITLE
feat: allow skipping NPM tagging

### DIFF
--- a/bin/magi-release
+++ b/bin/magi-release
@@ -169,6 +169,9 @@ async function main(version) {
 
       info('Publishing to npm');
       const tag = determineNpmTag(program, branch, newVersion);
+      if (tag === DUMMY_TAG_NAME) {
+        info(`Using dummy tag \`${DUMMY_TAG_NAME}\` in order to avoid publishing as \`latest\``);
+      }
       await exe(`npm publish --access public --tag ${tag}`);
       done(`Deployed to npm: ${npmUrl} with tag ${tag}`);
 

--- a/bin/magi-release
+++ b/bin/magi-release
@@ -19,13 +19,14 @@ function error(msg) {
   console.log(' [magi] ⚠️  ⚠️  \x1b[31m%s\x1b[0m ⚠️  ⚠️ \n', msg);
 }
 
-function determineNpmTag(program, newVersion) {
-  if (program.skipNpmTag) {
-    // npm publish has no options for not tagging release
-    // As a workaround we use a dummy tag, in order to prevent NPM overwriting the `latest` or `next` tags
+function determineNpmTag(program, branch, newVersion) {
+  // Use a dummy tag when not publishing from master, or when tagging is explicitly disabled
+  // We use a dummy tag since npm publish has no options for not tagging release
+  if (branch !== 'master' || program.skipNpmTag) {
     return DUMMY_TAG_NAME;
   }
 
+  // When publishing from master, determine whether to tag as `latest` or `next`
   const next = /(alpha|beta|pre|rc)[.]*[0-9]+$/;
   return next.test(newVersion) ? 'next' : 'latest';
 }
@@ -167,14 +168,17 @@ async function main(version) {
       }
 
       info('Publishing to npm');
-      if (branch === 'master') {
-        const tag = determineNpmTag(program, newVersion);
-        await exe(`npm publish --dry-run --access public --tag ${tag}`);
-        done(`Deployed to npm: ${npmUrl} with tag ${tag}`);
-      } else {
-        // Backported patch releases
-        await exe(`npm publish --access public --tag ${DUMMY_TAG_NAME}`);
-        done(`Deployed to npm: ${npmUrl}`);
+      const tag = determineNpmTag(program, branch, newVersion);
+      await exe(`npm publish --access public --tag ${tag}`);
+      done(`Deployed to npm: ${npmUrl} with tag ${tag}`);
+
+      // Remove dummy tag after publish
+      if (tag === DUMMY_TAG_NAME) {
+        try {
+          await exe(`npm dist-tag rm ${workingPackage.name} ${DUMMY_TAG_NAME}`);
+        } catch(_) {
+          // Ignore
+        }
       }
 
       // P2 component: restore master

--- a/bin/magi-release
+++ b/bin/magi-release
@@ -5,6 +5,8 @@ const program = require('commander');
 const fs = require('fs');
 const rimraf = require('rimraf');
 
+const DUMMY_TAG_NAME = "ignore"
+
 function info(msg) {
   console.log(' [magi] 🌀  \x1b[36m%s\x1b[0m ...', msg);
 }
@@ -17,10 +19,22 @@ function error(msg) {
   console.log(' [magi] ⚠️  ⚠️  \x1b[31m%s\x1b[0m ⚠️  ⚠️ \n', msg);
 }
 
+function determineNpmTag(program, newVersion) {
+  if (program.skipNpmTag) {
+    // npm publish has no options for not tagging release
+    // As a workaround we use a dummy tag, in order to prevent NPM overwriting the `latest` or `next` tags
+    return DUMMY_TAG_NAME;
+  }
+
+  const next = /(alpha|beta|pre|rc)[.]*[0-9]+$/;
+  return next.test(newVersion) ? 'next' : 'latest';
+}
+
 program
   .arguments('<version>')
   .option('--draft', 'Create the release in draft mode')
   .option('--skip-npm', 'Skip p3 conversion and npm deployment')
+  .option('--skip-npm-tag', 'Skip tagging the release in NPM as either `latest` or `next`. Use when releasing packages for older versions.')
   .option('--skip-cdn', 'Skip demo server deployment')
   .option('--skip-webjar', 'Skip webjar deployment')
   .parse(process.argv);
@@ -154,13 +168,12 @@ async function main(version) {
 
       info('Publishing to npm');
       if (branch === 'master') {
-        const next = /(alpha|beta|pre|rc)[.]*[0-9]+$/;
-        const tag = next.test(newVersion) ? 'next' : 'latest';
-        await exe(`npm publish --access public --tag ${tag}`);
+        const tag = determineNpmTag(program, newVersion);
+        await exe(`npm publish --dry-run --access public --tag ${tag}`);
         done(`Deployed to npm: ${npmUrl} with tag ${tag}`);
       } else {
         // Backported patch releases
-        await exe(`npm publish --access public`);
+        await exe(`npm publish --access public --tag ${DUMMY_TAG_NAME}`);
         done(`Deployed to npm: ${npmUrl}`);
       }
 


### PR DESCRIPTION
Adds a `--skip-npm-tag` option that prevents NPM from tagging the release as either `latest` or `next`. Note that npm publish does not actually allow disabling the tagging, so instead a catch-all dummy tag (`ignore`) is used for the release. Also when publishing from a branch that is not master, the dummy tag is used automatically. After publishing the package, the dummy tag is removed again.

If we go ahead with this, I'm going to update the release instructions for legacy components to add the flag for the release command.

Fixes: https://github.com/vaadin/magi-cli/issues/61