### PR TITLE
feat: enforce using lockfile in p3-convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.2.0-pre.1](https://github.com/vaadin/magi-cli/compare/v1.1.0...v1.2.0-pre.1) (2022-01-11)
+
+* enforce using lockfile in p3-convert ([#158](https://github.com/vaadin/magi-cli/issues/158))
+
+### Features
+
+* allow skipping NPM tagging ([#157](https://github.com/vaadin/magi-cli/issues/157)) ([fca7d38](https://github.com/vaadin/magi-cli/commit/fca7d38cbde3031968cfd227ba03ab24c85ed777))
+
 # [1.1.0](https://github.com/vaadin/magi-cli/compare/v1.0.2...v1.1.0) (2021-11-15)
 
 

--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -174,12 +174,19 @@ async function main() {
     to: '@extends PolymerElement'
   });
 
+  // Needed for gen-typescript-declarations to detect project type
+  rimraf.sync('bower_components');
+
+  // Use different lockfile for Polymer 3
+  if (fs.existsSync('package-lock-p3.json')) {
+    fs.renameSync('package-lock-p3.json', 'package-lock.json');
+  }
+
+  // Use npm ci to enforce lockfile
+  runSync('npm ci');
+
+  // Generate TypeScript definitions
   if (fs.existsSync('gen-tsd.json')) {
-    // Needed for gen-typescript-declarations to detect project type
-    rimraf.sync('bower_components');
-
-    runSync('npm install');
-
     runSync('npm run generate-typings');
 
     if (fs.existsSync(path.join('@types', 'interfaces.d.ts'))) {
@@ -192,13 +199,6 @@ async function main() {
       });
     }
   }
-
-  // Remove gen-typescript-declarations
-  replace.sync({
-    files: ['package.json'],
-    from: /.*"@web-padawan\/gen-typescript-declarations": "\^1\.6\.2",*\n/g,
-    to: ''
-  });
 }
 
 main()

--- a/lib/p3-post.js
+++ b/lib/p3-post.js
@@ -7,14 +7,12 @@ const fixme = `
 ;`
 
 const tsDefs = `"scripts": {
-  "generate-typings": "gen-typescript-declarations --outDir . --verify"
-},
-"devDependencies": {
-  "@web-padawan/gen-typescript-declarations": "^1.6.2",`;
-
-const resolutions = `"resolutions": {
-    "es-abstract": "1.17.6",
-    "@types/doctrine": "0.0.3",`;
+    "generate-typings": "gen-typescript-declarations --outDir . --verify",
+    "test": "wct --npm"
+  },
+  "devDependencies": {
+    "@web-padawan/gen-typescript-declarations": "^1.6.2",
+    "web-component-tester": "6.9.2",`;
 
  module.exports = {
   files: [
@@ -23,14 +21,12 @@ const resolutions = `"resolutions": {
   ],
   from: [
     '"devDependencies": {',
-    '"resolutions": {',
     "const $_documentContainer = document.createElement('template');",
     "$_documentContainer.innerHTML = `",
     fixme
   ],
   to: [
     tsDefs,
-    resolutions,
     "import { html } from '@polymer/polymer/lib/utils/html-tag.js';",
     "const $_documentContainer = html`",
     ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "magi-cli",
-  "version": "1.1.0",
+  "version": "1.2.0-pre.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magi-cli",
-  "version": "1.1.0",
+  "version": "1.2.0-pre.1",
   "description": "Elements team command-line team member",
   "main": "./bin/magi",
   "bin": {


### PR DESCRIPTION
## Description

Connected to https://github.com/vaadin/components-team-tasks/issues/602

1. From now on, we assume that individual repositories keep `package-lock.json` in version control
2. Added logic to handle `package-lock-p3.json` renaming (the file needs to be created manually)

To use this feature, the following changes are needed:

1. Use this branch: https://github.com/vaadin/vaadin-component-dev-dependencies/tree/feat/lockfile
2. Remove `yarn install --flat` from the GitHub Actions P3 workflows due to [launchpad issue](https://github.com/vaadin/components-team-tasks/issues/602#issuecomment-1009736545).

## Type of change

- Feature