### PR TITLE
fix: do not override custom p3-post scripts

### DIFF
--- a/bin/magi-p3-convert
+++ b/bin/magi-p3-convert
@@ -174,6 +174,19 @@ async function main() {
     to: '@extends PolymerElement'
   });
 
+  // Read the updated package.json
+  const updatedPackage = JSON.parse(fs.readFileSync('package.json'));
+
+  if (!updatedPackage.scripts) {
+    updatedPackage.scripts = {};
+  }
+
+  updatedPackage.scripts['generate-typings'] = 'gen-typescript-declarations --outDir . --verify';
+  updatedPackage.scripts.test = 'wct --npm';
+
+  // Format and write changes to package.json
+  jsonfile.writeFileSync('package.json', updatedPackage, {spaces: 2});
+
   // Needed for gen-typescript-declarations to detect project type
   rimraf.sync('bower_components');
 

--- a/lib/p3-post.js
+++ b/lib/p3-post.js
@@ -6,11 +6,7 @@ const fixme = `
 */
 ;`
 
-const tsDefs = `"scripts": {
-    "generate-typings": "gen-typescript-declarations --outDir . --verify",
-    "test": "wct --npm"
-  },
-  "devDependencies": {
+const tsDefs = `"devDependencies": {
     "@web-padawan/gen-typescript-declarations": "^1.6.2",
     "web-component-tester": "6.9.2",`;
 


### PR DESCRIPTION
## Description

Updated to not override `"scripts"` section provided by custom `magi-p3-post.json` like in usage statistics.

Related to https://github.com/vaadin/vaadin-usage-statistics/issues/52

## Type of change

- Bugfix